### PR TITLE
Added parallel directory busting feature in directory buster script

### DIFF
--- a/DirectoryBusting/README.md
+++ b/DirectoryBusting/README.md
@@ -19,15 +19,16 @@ Run the script as:
 ## Usage Details
 
 ```
-usage: directoryBuster.py [-h] [-dict DICT] [-r] [-t T] [-url URL] [-v]
+usage: directoryBuster.py [-h] [-dict DICT] [-r] [-p P] [-t T] [-url URL] [-v]
 
 optional arguments:
   -h, --help  show this help message and exit
   -dict DICT  Dictionary to use
   -r          Be recursive
-  -t T        Number of Threads
+  -p P        Number of parallel directories to bruteforce
+  -t T        Number of Threads to bust each directory
   -url URL    Url to bust
-  -v          Show all url attempts
+  -v          Show all url attempts      Show all url attempts
 ```
 
 ## Example Image

--- a/DirectoryBusting/directoryBuster.py
+++ b/DirectoryBusting/directoryBuster.py
@@ -14,6 +14,8 @@ class DirectoryBuster:
         self.totalWords = 0
         self.initialWords = 0
         self.attemptCount = 0
+        self.directoryThreadsCount = 1
+        self.wordlist = None
         self.foundSubdirectories = deque()
         self.threadQueue = Queue()
         self.parser = argparse.ArgumentParser()
@@ -23,7 +25,8 @@ class DirectoryBuster:
     def setupArgs(self):
         self.parser.add_argument('-dict', help='Dictionary to use')
         self.parser.add_argument('-r', help='Be recursive', action='store_true')
-        self.parser.add_argument('-t', help='Number of Threads', default=1)
+        self.parser.add_argument('-p', help='Number of parallel directories to bruteforce', default=1)
+        self.parser.add_argument('-t', help='Number of Threads to bust each directory', default=5)
         self.parser.add_argument('-url', help='Url to bust')
         self.parser.add_argument('-v', help='Show all url attempts', action='store_true')
         args = self.parser.parse_args()
@@ -41,6 +44,7 @@ class DirectoryBuster:
         try:
             with open(args.dict) as dictionary:
                 words = dictionary.readlines()
+                self.wordlist = words
                 threadLimit = int(args.t)
                 self.initialWords = len(words)
                 blockSize = self.initialWords // threadLimit
@@ -55,18 +59,7 @@ class DirectoryBuster:
                 args.url = args.url.strip()
 
                 subdirectory = self.foundSubdirectories.popleft()
-                for threadNumber in range(threadLimit - 1):
-                    lowerBound = threadNumber * blockSize
-                    upperBound = (threadNumber + 1) * blockSize - 1
-                    bustingThread = threading.Thread(target=self.bustingThread, args=(words[lowerBound:upperBound], args, subdirectory, False))
-                    bustingThread.daemon = True
-                    bustingThread.start()
-                    self.threadQueue.put(bustingThread)
-
-                bustingThread = threading.Thread(target=self.bustingThread, args=(words[(threadLimit-1)*blockSize:], args, subdirectory, True))
-                bustingThread.daemon = True
-                bustingThread.start()
-                self.threadQueue.put(bustingThread)
+                self.directoryThread(words, args, subdirectory, threadLimit, blockSize)
 
                 while not self.threadQueue.empty():
                     self.threadQueue.get().join()
@@ -78,7 +71,21 @@ class DirectoryBuster:
             print('\033[93mDictionary file not found!')
             exit()
 
-    def bustingThread(self, words, args, subdirectory, isLastThread):
+    def directoryThread(self, words, args, subdirectory, threadLimit, blockSize):
+        for threadNumber in range(threadLimit - 1):
+            lowerBound = threadNumber * blockSize
+            upperBound = (threadNumber + 1) * blockSize - 1
+            bustingThread = threading.Thread(target=self.bustingThread, args=(words[lowerBound:upperBound], args, subdirectory, False, threadLimit, blockSize))
+            bustingThread.daemon = True
+            bustingThread.start()
+            self.threadQueue.put(bustingThread)
+
+        bustingThread = threading.Thread(target=self.bustingThread, args=(words[(threadLimit-1)*blockSize:], args, subdirectory, True, threadLimit, blockSize))
+        bustingThread.daemon = True
+        bustingThread.start()
+        self.threadQueue.put(bustingThread)
+
+    def bustingThread(self, words, args, subdirectory, isLastThread, threadLimit, blockSize):
 
         for link in words:
 
@@ -97,7 +104,17 @@ class DirectoryBuster:
                     print('\033[93m{} (status code: {})'.format(dest, resp.status_code))
 
                 if (link != '' and args.r):
-                    self.foundSubdirectories.append('/{}/'.format(link))
+                    newSubdirectory = '/{}/'.format(link)
+
+                    if (self.directoryThreadsCount < int(args.p)):
+                        self.directoryThreadsCount += 1
+                        directoryThread = threading.Thread(target=self.directoryThread, args=(self.wordlist, args, newSubdirectory, threadLimit, blockSize))
+                        directoryThread.daemon = True
+                        directoryThread.start()
+                        self.threadQueue.put(directoryThread)
+                    else:
+                        self.foundSubdirectories.append(newSubdirectory)
+
                     self.totalWords += self.initialWords
 
             elif(args.v):
@@ -108,6 +125,6 @@ class DirectoryBuster:
                 nextSubdirectory = self.foundSubdirectories.pop()
             else:
                 nextSubdirectory = self.foundSubdirectories[0]
-            self.bustingThread(words, args, nextSubdirectory, isLastThread)
+            self.bustingThread(words, args, nextSubdirectory, isLastThread, threadLimit, blockSize)
 
 DirectoryBuster()


### PR DESCRIPTION
# Description

This PR adds a feature for parallel directory busting in the directory buster script.

## Related issue #92 

## Have you read the [Contributing Guidelines on Pull Requests](https://github.com/dscciem/Pentesting-and-Hacking-Scripts/blob/master/CONTRIBUTING.md)?

- [x] Yes
- [ ] No

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation Update

## Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I've edited the [`SCRIPTS.md`](https://github.com/dscciem/Pentesting-and-Hacking-Scripts/blob/master/SCRIPTS.md) and link to my code.
- [x] I have created a helpful and easy to understand `README.md`
- [x] My documentation follows [`Template for README.md`](https://github.com/dscciem/Pentesting-and-Hacking-Scripts/blob/master/Template%20for%20README.md)
- [x] My changes generate no new warnings
- [x] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works.
